### PR TITLE
修改json方法、缓存Response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ res, err := req.Post("http://127.0.0.1:8000", map[string]interface{}{
 })
 ```
 
-Print JSON
+Unmarshal JSON
 ```go
-body, err := res.Json()
+var u User
+err := res.Json(&u)
 if err != nil {
    return
 }
@@ -206,10 +207,24 @@ Time() string
 res.Time()  //ms
 ```
 
-Json() (string,error)
+Json(v interface{}) error
 ```go
-body, err := res.Json() //Format the json return value
-log.Println(body)
+var u User
+err := res.Json(&u) //Format the json
+log.Println(u)
+```
+
+JsonMap() (map[string]interface{},error)
+```go
+
+m,err := res.JsonMap() //Format the json return map
+log.Println(u)
+```
+
+JsonString() (string,error)
+```go
+s,err := res.JsonString() //Format the json return string
+log.Println(s)
 ```
 
 Url() string

--- a/response.go
+++ b/response.go
@@ -36,10 +36,10 @@ func (r *Response) Url() string {
 
 func (r *Response) Headers() map[string]string {
 	headers := make(map[string]string)
-	for k, v := range r.resp.Header {
-		if len(v) > 0 {
+	for k,v:=range r.resp.Header{
+		if len(v)>0{
 			headers[k] = v[len(v)-1]
-		} else {
+		}else{
 			headers[k] = ""
 		}
 	}


### PR DESCRIPTION
1. Json()用于解析json结构，而不是单纯返回字符串。原来的Json()改名为jsonString()

2. 缓存Response body，否则重复调用res.Body()会出错